### PR TITLE
Update nav data compression format

### DIFF
--- a/laika/downloader.py
+++ b/laika/downloader.py
@@ -225,14 +225,16 @@ def download_nav(time, cache_dir, constellation='GPS'):
       elif constellation =='GLONASS':
         filename = t.strftime("brdc%j0.%yg")
         folder_path = t.strftime('%Y/%j/%yg/')
-      return download_and_cache_file(url_base, folder_path, cache_subdir, filename, compression='.Z')
+      compression = '.gz' if folder_path >= '2020/335/' else '.Z'
+      return download_and_cache_file(url_base, folder_path, cache_subdir, filename, compression=compression)
     else:
       url_base = 'https://cddis.nasa.gov/archive/gnss/data/hourly/'
       cache_subdir = cache_dir + 'hourly_nav/'
       if constellation =='GPS':
         filename = t.strftime("hour%j0.%yn")
         folder_path = t.strftime('%Y/%j/')
-        return download_and_cache_file(url_base, folder_path, cache_subdir, filename, compression='.Z', overwrite=True)
+        compression = '.gz' if folder_path >= '2020/336/' else '.Z'
+        return download_and_cache_file(url_base, folder_path, cache_subdir, filename, compression=compression, overwrite=True)
   except IOError:
     pass
 


### PR DESCRIPTION
The compression format for nav data was changed from `.Z` to `.gz` in December. 

So, right before the change:
* https://cddis.nasa.gov/archive/gnss/data/daily/2020/334/20n/brdc3340.20n.Z
* https://cddis.nasa.gov/archive/gnss/data/hourly/2020/335/hour3350.20n.Z

and after:
* https://cddis.nasa.gov/archive/gnss/data/daily/2020/335/20n/brdc3350.20n.gz
* https://cddis.nasa.gov/archive/gnss/data/hourly/2020/336/hour3360.20n.gz