### PR TITLE
Use trop delay when offline

### DIFF
--- a/laika/astro_dog.py
+++ b/laika/astro_dog.py
@@ -282,18 +282,19 @@ class AstroDog:
     if el < 0.2:
       return None
 
-    if self.dgps and not no_dgps:
+    if self.use_internet and self.dgps and not no_dgps:
       return self._get_delay_dgps(prn, rcv_pos, time)
 
-    if not freq:
-      freq = self.get_frequency(prn, time, signal)
     ionex = self.get_ionex(time)
+    if not freq and ionex is not None:
+      freq = self.get_frequency(prn, time, signal)
     dcb = self.get_dcb(prn, time)
-    if ionex is None or dcb is None or freq is None:
+    # When using internet we expect all data or return None
+    if self.use_internet and (ionex is None or dcb is None or freq is None):
       return None
-    iono_delay = ionex.get_delay(rcv_pos, az, el, sat_pos, time, freq)
+    iono_delay = ionex.get_delay(rcv_pos, az, el, sat_pos, time, freq) if ionex is not None else 0.
     trop_delay = saast(rcv_pos, el)
-    code_bias = dcb.get_delay(signal)
+    code_bias = dcb.get_delay(signal) if dcb is not None else 0.
     return iono_delay + trop_delay + code_bias
 
   def _get_delay_dgps(self, prn, rcv_pos, time):

--- a/laika/astro_dog.py
+++ b/laika/astro_dog.py
@@ -282,7 +282,7 @@ class AstroDog:
     if el < 0.2:
       return None
 
-    if self.use_internet and self.dgps and not no_dgps:
+    if self.dgps and not no_dgps:
       return self._get_delay_dgps(prn, rcv_pos, time)
 
     ionex = self.get_ionex(time)

--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -121,8 +121,8 @@ class GNSSMeasurement:
     if not self.corrected:
       raise NotImplementedError('Only corrected measurements can be put into arrays')
     ret = np.array([self.get_nmea_id(), self.recv_time_week, self.recv_time_sec, self.glonass_freq,
-                  self.observables_final['C1C'], self.observables_std['C1C'],
-                  self.observables_final['D1C'], self.observables_std['D1C']])
+                    self.observables_final['C1C'], self.observables_std['C1C'],
+                    self.observables_final['D1C'], self.observables_std['D1C']])
     return np.concatenate((ret, self.sat_pos_final, self.sat_vel))
 
   def __repr__(self):


### PR DESCRIPTION
With trop delay we can get a closer estimate to the delay when not having access to ionex and dcb data.

Verified by processing ephemeris data.