### PR TITLE
Download Ulra-orbit predictions for GPS and Glonass

### DIFF
--- a/laika/astro_dog.py
+++ b/laika/astro_dog.py
@@ -37,6 +37,7 @@ class AstroDog:
     self.use_internet = use_internet
     self.cache_dir = cache_dir
     self.dgps = dgps
+    # todo check that final/rapid are not combined with ultra
     if not isinstance(valid_ephem_types, Iterable):
       valid_ephem_types = [valid_ephem_types]
     self.pull_orbit = len(set(EphemerisType.all_orbits()) & set(valid_ephem_types)) > 0
@@ -162,6 +163,9 @@ class AstroDog:
   def download_parse_orbit_data(self, gps_time: GPSTime, skip_before_epoch=None) -> List[PolyEphemeris]:
     # Download multiple days to be able to polyfit at the start-end of the day
     time_steps = [gps_time - SECS_IN_DAY, gps_time, gps_time + SECS_IN_DAY]
+    # Assume Ultra-rapid is only used for online data. Only download next day if we use Final or Rapid orbits.
+    if EphemerisType.ULTRA_RAPID_ORBIT in self.valid_ephem_types:
+      time_steps = [gps_time]
     with ThreadPoolExecutor() as executor:
       futures_other = [executor.submit(download_orbits_russia_src, t, self.cache_dir, self.valid_ephem_types) for t in time_steps]
       futures_gps = None

--- a/laika/downloader.py
+++ b/laika/downloader.py
@@ -353,7 +353,6 @@ def download_orbits_russia_src(time, cache_dir, ephem_types):
     'ftp://ftp.glonass-iac.ru/MCC/PRODUCTS/',
   )
   t = time.as_datetime()
-  current_gps_time = GPSTime.from_datetime(datetime.utcnow())
   if EphemerisType.ULTRA_RAPID_ORBIT in ephem_types:
     # Download predictions
     file_prefix = "Stark_1D_" + t.strftime('%y%m%d')
@@ -372,7 +371,7 @@ def download_orbits_russia_src(time, cache_dir, ephem_types):
 
   folder_paths = []
   filename = "Sta%i%i.sp3" % (time.week, time.day)
-  if EphemerisType.FINAL_ORBIT in ephem_types and current_gps_time - time > 2 * SECS_IN_WEEK:
+  if EphemerisType.FINAL_ORBIT in ephem_types and GPSTime.from_datetime(datetime.utcnow()) - time > 2 * SECS_IN_WEEK:
     folder_paths.append(t.strftime('%y%j/final/'))
   if EphemerisType.RAPID_ORBIT in ephem_types:
     folder_paths.append(t.strftime('%y%j/rapid/'))

--- a/laika/ephemeris.py
+++ b/laika/ephemeris.py
@@ -349,7 +349,7 @@ def read_prn_data(data, prn, deg=16, deg_t=1):
   # TODO Handle this properly
   np_data_prn = np.array(data[prn])
   # Currently, don't even bother with satellites that have unhealthy times
-  if (np_data_prn[:, 5] > .99).any():
+  if len(np_data_prn) == 0 or (np_data_prn[:, 5] > .99).any():
     return []
   ephems = []
   for i in range(len(np_data_prn) - deg):


### PR DESCRIPTION
Download them in efficient order. 
Skipping _18 predictions from the same day since they are released a day later.

Made the assumption that people either use Laika only for observations with types Final or Rapid or just use predictions with Ultra-rapid.