### PR TITLE
Use all orbit types as default in AstroDog

### DIFF
--- a/laika/astro_dog.py
+++ b/laika/astro_dog.py
@@ -26,14 +26,14 @@ class AstroDog:
                data to calculate pseudorange corrections
   valid_const: list of constellation identifiers laika will try process
   valid_ephem_types: set of ephemeris types that are allowed to use and download.
-                Default is set to use observation orbit ephemeris types (orbits observations are the most accurate)
+                Default is set to use all orbit ephemeris types
   '''
 
   def __init__(self, use_internet=True,
                cache_dir='/tmp/gnss/',
                dgps=False,
                valid_const=('GPS', 'GLONASS'),
-               valid_ephem_types=EphemerisType.observation_orbits()):
+               valid_ephem_types=EphemerisType.all_orbits()):
     self.use_internet = use_internet
     self.cache_dir = cache_dir
     self.dgps = dgps

--- a/laika/ephemeris.py
+++ b/laika/ephemeris.py
@@ -75,11 +75,6 @@ class EphemerisType(IntEnum):
   def all_orbits():
     return EphemerisType.FINAL_ORBIT, EphemerisType.RAPID_ORBIT, EphemerisType.ULTRA_RAPID_ORBIT
 
-  @staticmethod
-  def observation_orbits():
-    # Orbit types without predictions
-    return EphemerisType.FINAL_ORBIT, EphemerisType.RAPID_ORBIT
-
   @classmethod
   def from_file_name(cls, file_name: str):
     if "/final" in file_name or "/igs" in file_name:

--- a/tests/test_ephemerides.py
+++ b/tests/test_ephemerides.py
@@ -31,7 +31,7 @@ class TestAstroDog(unittest.TestCase):
   '''
 
   def test_nav_vs_orbit__old(self):
-    dog_orbit = AstroDog(valid_ephem_types=EphemerisType.observation_orbits())
+    dog_orbit = AstroDog(valid_ephem_types=EphemerisType.all_orbits())
     dog_nav = AstroDog(valid_ephem_types=EphemerisType.NAV)
     for gps_time in gps_times:
       for svId in svIds:

--- a/tests/test_fail_caching.py
+++ b/tests/test_fail_caching.py
@@ -13,7 +13,7 @@ gps_times = [GPSTime(*gps_time_list) for gps_time_list in gps_times_list]
 
 class TestFailCache(unittest.TestCase):
   def test_no_infinite_pulls(self):
-    dog = AstroDog(valid_ephem_types=EphemerisType.observation_orbits())
+    dog = AstroDog(valid_ephem_types=EphemerisType.all_orbits())
     for gps_time in gps_times:
       for svId in svIds:
         dog.get_sat_info(svId, gps_time)

--- a/tests/test_fetch_sat_info.py
+++ b/tests/test_fetch_sat_info.py
@@ -30,7 +30,7 @@ class TestFetchSatInfo(unittest.TestCase):
 
   def test_get_all_sat_info_gps(self):
     time = GPSTime.from_datetime(datetime(2020, 5, 1, 12, 0, 0))
-    orbit_types = EphemerisType.observation_orbits()
+    orbit_types = EphemerisType.all_orbits()
     only_nav = EphemerisType.NAV
     kwargs_list = [
         {"valid_const": ["GPS"], "valid_ephem_types": orbit_types},


### PR DESCRIPTION
I made the wrong assumption that Ultra-Orbit where not used regularly. This reverts the change and uses all orbit types by default.