### PR TITLE
Optimize polyfit and polyval for orbits

### DIFF
--- a/laika/astro_dog.py
+++ b/laika/astro_dog.py
@@ -196,7 +196,6 @@ class AstroDog:
 
     if len(ephems_sp3) != 0:
       min_epoch, max_epoch = self.get_epoch_range(ephems_sp3)
-      print(min_epoch.as_datetime(), max_epoch.as_datetime())
       self.orbit_fetched_times.add(min_epoch, max_epoch)
 
   def get_dcb_data(self, time):

--- a/laika/ephemeris.py
+++ b/laika/ephemeris.py
@@ -340,7 +340,6 @@ def parse_sp3_orbits(file_names, supported_constellations, skip_until_epoch: Opt
     ephems.extend(read_prn_data(data, prn))
   return ephems
 
-
 def read_prn_data(data, prn, deg=16, deg_t=1):
   # TODO Handle this properly
   np_data_prn = np.array(data[prn])
@@ -356,11 +355,10 @@ def read_prn_data(data, prn, deg=16, deg_t=1):
     times = (measurements[:, 0] - epoch).astype(float)
     if (np.diff(times) != 900).any():
       continue
-    x, y, z = measurements[:, 1:].astype(float).transpose()
-
+    
     poly_data = {}
     poly_data['t0'] = epoch
-    poly_data['xyz'] = poly.polyfit(times, np.array([x,y,z]).transpose(), deg)
+    poly_data['xyz'] = poly.polyfit(times, measurements[:, 1:].astype(float), deg)
     poly_data['clock'] = [(np_data_prn[epoch_index + 1][5] - np_data_prn[epoch_index - 1][5]) / 1800, np_data_prn[epoch_index][5]]
     poly_data['deg'] = deg
     poly_data['deg_t'] = deg_t

--- a/laika/ephemeris.py
+++ b/laika/ephemeris.py
@@ -191,9 +191,9 @@ class PolyEphemeris(Ephemeris):
     deg = self.data['deg']
     deg_t = self.data['deg_t']
     indices = np.arange(deg+1)[:,np.newaxis]
-    sat_pos = np.sum(self.data['xyz']*(dt**indices), axis=0)
+    sat_pos = np.sum((dt**indices)*self.data['xyz'], axis=0)
     indices = indices[1:]
-    sat_vel = np.sum(self.data['xyz'][1:]*indices*(dt**(indices-1)), axis=0)
+    sat_vel = np.sum(indices*(dt**(indices-1)*self.data['xyz'][1:]), axis=0)
     time_err = sum((dt**p)*self.data['clock'][deg_t-p] for p in range(deg_t+1))
     time_err_rate = sum(p*(dt**(p-1))*self.data['clock'][deg_t-p] for p in range(1,deg_t+1))
     time_err_with_rel = time_err - 2*np.inner(sat_pos, sat_vel)/SPEED_OF_LIGHT**2

--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -1,3 +1,4 @@
+from math import sqrt
 from typing import Dict, List, Union
 
 import scipy.optimize as opt
@@ -74,11 +75,11 @@ class GNSSMeasurement:
     self.corrected = False
 
     # sat info
-    self.sat_pos = np.nan * np.ones(3)
-    self.sat_vel = np.nan * np.ones(3)
+    self.sat_pos = np.array([np.nan, np.nan, np.nan])
+    self.sat_vel = np.array([np.nan, np.nan, np.nan])
     self.sat_clock_err = np.nan
 
-    self.sat_pos_final = np.nan * np.ones(3)  # sat_pos in receiver time's ECEF frame instead of satellite time's ECEF frame
+    self.sat_pos_final = np.array([np.nan, np.nan, np.nan])  # sat_pos in receiver time's ECEF frame instead of satellite time's ECEF frame
     self.observables_final: Dict[str, float] = {}
 
   def process(self, dog):
@@ -239,7 +240,7 @@ def read_raw_ublox(report) -> List[GNSSMeasurement]:
         observables['C1C'] = i.pseudorange
         # Empirically it seems obvious ublox's std is
         # actually a variation
-        observables_std['C1C'] = np.sqrt(i.pseudorangeStdev)*10
+        observables_std['C1C'] = sqrt(i.pseudorangeStdev)*10
         if i.gnssId == ConstellationId.GLONASS:
           glonass_freq = i.glonassFrequencyIndex - 7
           observables['D1C'] = -(constants.SPEED_OF_LIGHT / (constants.GLONASS_L1 + glonass_freq * constants.GLONASS_L1_DELTA)) * i.doppler


### PR DESCRIPTION
Orbit polyfit is reduced by 50%. (3 polyfits for each axis took 852.6ns on average. While all at once takes 413.7ns)
Poly evaluation is reduced by 15%. 
Also verified speedup in laikad: (Averages of processing a segment 4 times)
New:
Time per hit: 1384316.2  self.fetch_orbits
Time per hit: 1473.7       processed_measurements 
Old:
Time per hit: 2473399.0       self.fetch_orbits
Time per hit: 1840.1       processed_measurements

The code is covered by unit test.