### PR TITLE
Filter all measurements with pseudorange outside of [1e7,3e7]

### DIFF
--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -231,7 +231,7 @@ def read_raw_ublox(report) -> List[GNSSMeasurement]:
   for i in report.measurements:
     # only add Gps and Glonass fixes
     if i.gnssId in [ConstellationId.GPS, ConstellationId.GLONASS]:
-      if i.svId > 32 or i.pseudorange > 1e8:
+      if i.svId > 32 or i.pseudorange < 1e7 or i.pseudorange > 3e7:
         continue
       observables = {}
       observables_std = {}

--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -100,6 +100,7 @@ class GNSSMeasurement:
           self.observables_final[obs] = (self.observables[obs] +
                                          self.sat_clock_err*constants.SPEED_OF_LIGHT -
                                          delay)
+          print("self.observables_final[obs]", self.observables_final[obs])
       else:
         self.observables_final[obs] = self.observables[obs]
     if 'C1C' in self.observables_final and 'C2P' in self.observables_final:
@@ -231,7 +232,7 @@ def read_raw_ublox(report) -> List[GNSSMeasurement]:
   for i in report.measurements:
     # only add Gps and Glonass fixes
     if i.gnssId in [ConstellationId.GPS, ConstellationId.GLONASS]:
-      if i.svId > 32 or i.pseudorange > 2**32:
+      if i.svId > 32 or i.pseudorange > 1e9:
         continue
       observables = {}
       observables_std = {}

--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -100,7 +100,6 @@ class GNSSMeasurement:
           self.observables_final[obs] = (self.observables[obs] +
                                          self.sat_clock_err*constants.SPEED_OF_LIGHT -
                                          delay)
-          print("self.observables_final[obs]", self.observables_final[obs])
       else:
         self.observables_final[obs] = self.observables[obs]
     if 'C1C' in self.observables_final and 'C2P' in self.observables_final:
@@ -232,7 +231,7 @@ def read_raw_ublox(report) -> List[GNSSMeasurement]:
   for i in report.measurements:
     # only add Gps and Glonass fixes
     if i.gnssId in [ConstellationId.GPS, ConstellationId.GLONASS]:
-      if i.svId > 32 or i.pseudorange > 1e9:
+      if i.svId > 32 or i.pseudorange > 1e8:
         continue
       observables = {}
       observables_std = {}


### PR DESCRIPTION
Some satellites have a very incorrect pseudorange either negative or a very high number which isn't possible.
Filtering pseudoranges outside of the range [1e7,3e7] removes most measurements that cannot be corrected. From all the 1000 segments shown in this plot it would remove the top 1.5% and <0.0001 % of the lowest pseudoranges.
![image](https://user-images.githubusercontent.com/4709833/177585847-ad118855-7acb-459f-9841-957c84414adf.png)
