### PR TITLE
Allow correcting measurements with zero delay

### DIFF
--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -92,11 +92,11 @@ class GNSSMeasurement:
     self.processed = True
     return True
 
-  def correct(self, est_pos, dog, delay_not_zero=True):
+  def correct(self, est_pos, dog, allow_incomplete_delay=False):
     for obs in self.observables:
       if obs[0] == 'C':  # or obs[0] == 'L':
         delay = dog.get_delay(self.prn, self.recv_time, est_pos, signal=obs)
-        if delay is not None and (delay != 0 or not delay_not_zero):
+        if delay is not None and (delay != 0 or allow_incomplete_delay):
           self.observables_final[obs] = (self.observables[obs] +
                                          self.sat_clock_err*constants.SPEED_OF_LIGHT -
                                          delay)
@@ -147,10 +147,10 @@ def process_measurements(measurements: List[GNSSMeasurement], dog) -> List[GNSSM
   return proc_measurements
 
 
-def correct_measurements(measurements: List[GNSSMeasurement], est_pos, dog, delay_not_zero=True) -> List[GNSSMeasurement]:
+def correct_measurements(measurements: List[GNSSMeasurement], est_pos, dog, allow_incomplete_delay=False) -> List[GNSSMeasurement]:
   corrected_measurements = []
   for meas in measurements:
-    if meas.correct(est_pos, dog, delay_not_zero):
+    if meas.correct(est_pos, dog, allow_incomplete_delay):
       corrected_measurements.append(meas)
   return corrected_measurements
 

--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -96,7 +96,7 @@ class GNSSMeasurement:
     for obs in self.observables:
       if obs[0] == 'C':  # or obs[0] == 'L':
         delay = dog.get_delay(self.prn, self.recv_time, est_pos, signal=obs)
-        if delay:
+        if delay is not None:
           self.observables_final[obs] = (self.observables[obs] +
                                          self.sat_clock_err*constants.SPEED_OF_LIGHT -
                                          delay)

--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -96,7 +96,7 @@ class GNSSMeasurement:
     for obs in self.observables:
       if obs[0] == 'C':  # or obs[0] == 'L':
         delay = dog.get_delay(self.prn, self.recv_time, est_pos, signal=obs)
-        if delay is not None and (delay != 0 or allow_incomplete_delay):
+        if delay != 0 or (allow_incomplete_delay and delay is not None):
           self.observables_final[obs] = (self.observables[obs] +
                                          self.sat_clock_err*constants.SPEED_OF_LIGHT -
                                          delay)

--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -117,19 +117,13 @@ class GNSSMeasurement:
       return True
     return False
 
-  def as_array(self, only_corrected=True):
-    observables = self.observables_final
-    sat_pos = self.sat_pos_final
+  def as_array(self):
     if not self.corrected:
-      if only_corrected:
-        raise NotImplementedError('Only corrected measurements can be put into arrays')
-      else:
-        observables = self.observables
-        sat_pos = self.sat_pos
+      raise NotImplementedError('Only corrected measurements can be put into arrays')
     ret = np.array([self.get_nmea_id(), self.recv_time_week, self.recv_time_sec, self.glonass_freq,
-                    observables['C1C'], self.observables_std['C1C'],
-                    observables['D1C'], self.observables_std['D1C']])
-    return np.concatenate((ret, sat_pos, self.sat_vel))
+                    self.observables_final['C1C'], self.observables_std['C1C'],
+                    self.observables_final['D1C'], self.observables_std['D1C']])
+    return np.concatenate((ret, self.sat_pos_final, self.sat_vel))
 
   def __repr__(self):
     time = self.recv_time.as_datetime().strftime('%Y-%m-%dT%H:%M:%S.%f')

--- a/laika/raw_gnss.py
+++ b/laika/raw_gnss.py
@@ -96,7 +96,7 @@ class GNSSMeasurement:
     for obs in self.observables:
       if obs[0] == 'C':  # or obs[0] == 'L':
         delay = dog.get_delay(self.prn, self.recv_time, est_pos, signal=obs)
-        if delay != 0 or (allow_incomplete_delay and delay is not None):
+        if delay is not None and (allow_incomplete_delay or delay != 0):
           self.observables_final[obs] = (self.observables[obs] +
                                          self.sat_clock_err*constants.SPEED_OF_LIGHT -
                                          delay)


### PR DESCRIPTION
Laikad isn't always able to calculate a delay when its position isn't good. This allows to use a better measurement for the kalman filter by correcting for the clock error while the delay is still zero.

Default behaviour is unchanged.