### PR TITLE
Fix leap second in 2017

### DIFF
--- a/laika/gps_time.py
+++ b/laika/gps_time.py
@@ -62,8 +62,7 @@ def get_leap_seconds(time):
     return 15
   elif time <= GPSTime.from_datetime(datetime.datetime(2015, 7, 1)):
     return 16
-  # TODO is this correct?
-  elif time <= GPSTime.from_datetime(datetime.datetime(2017, 7, 1)):
+  elif time <= GPSTime.from_datetime(datetime.datetime(2017, 1, 1)):
     return 17
   else:
     return 18

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -87,7 +87,7 @@ class TestTime(unittest.TestCase):
                          '2016-04-08 12:28:19',
                          '2017-10-23 06:42:34',
                          '2018-01-18 03:16:27',
-                         '2017-07-01 00:00:05']
+                         '2017-01-01 00:00:05']
     gps_times = [GPSTime.from_datetime(datetime.strptime(dt_str, '%Y-%m-%d %H:%M:%S')) for dt_str in datetimes_strings]
     np.testing.assert_allclose((gps_times[0] - gpst_to_utc(gps_times[0])), 14, rtol=0, atol=1e-3)
     np.testing.assert_allclose((gps_times[1] - gpst_to_utc(gps_times[1])), 15, rtol=0, atol=1e-3)


### PR DESCRIPTION
The leap second in 2017 specified in the `get_leap_seconds` function in the `backend/core/orbital/gpstime.go` file is wrong.

The starting date for the leap second from 2017 is set to 2017-07-01, but the correct date is 2017-01-01. See the [official IETF list](https://www.ietf.org/timezones/data/leap-seconds.list).

This MR fixes the problem.