### PR TITLE
GPS ephemeris parsing: fix week increase

### DIFF
--- a/laika/ephemeris.py
+++ b/laika/ephemeris.py
@@ -38,9 +38,10 @@ def convert_ublox_gps_ephem(ublox_ephem, current_time: Optional[datetime] = None
     roll_overs = GPSTime.from_datetime(current_time).week // 1024
     week += (roll_overs - (week // 1024)) * 1024
 
-  # GPSweek refers to current week, the ephemeris can be valid for the next
-  # week this is indenticated by toe equals 0
-  if ublox_ephem.toe == 0:
+  # GPS week refers to current week, the ephemeris can be valid for the next
+  # if toe equals 0, this can be verified by the TOW count if it is within the
+  # last 2 hours of the week (gps ephemeris valid for 4hours)
+  if ublox_ephem.toe == 0 and ublox_ephem.towCount*6 >=  (SECS_IN_WEEK - 2*SECS_IN_HR):
     week += 1
 
   ephem = {}

--- a/laika/ephemeris.py
+++ b/laika/ephemeris.py
@@ -41,7 +41,7 @@ def convert_ublox_gps_ephem(ublox_ephem, current_time: Optional[datetime] = None
   # GPS week refers to current week, the ephemeris can be valid for the next
   # if toe equals 0, this can be verified by the TOW count if it is within the
   # last 2 hours of the week (gps ephemeris valid for 4hours)
-  if ublox_ephem.toe == 0 and ublox_ephem.towCount*6 >=  (SECS_IN_WEEK - 2*SECS_IN_HR):
+  if ublox_ephem.toe == 0 and ublox_ephem.towCount*6 >= (SECS_IN_WEEK - 2*SECS_IN_HR):
     week += 1
 
   ephem = {}

--- a/laika/ephemeris.py
+++ b/laika/ephemeris.py
@@ -38,6 +38,11 @@ def convert_ublox_gps_ephem(ublox_ephem, current_time: Optional[datetime] = None
     roll_overs = GPSTime.from_datetime(current_time).week // 1024
     week += (roll_overs - (week // 1024)) * 1024
 
+  # GPSweek refers to current week, the ephemeris can be valid for the next
+  # week this is indenticated by toe equals 0
+  if ublox_ephem.toe == 0:
+    week += 1
+
   ephem = {}
   ephem['sv_id'] = ublox_ephem.svId
   ephem['toe'] = GPSTime(week, ublox_ephem.toe)

--- a/tests/test_ephemerides.py
+++ b/tests/test_ephemerides.py
@@ -70,19 +70,19 @@ class TestAstroDog(unittest.TestCase):
     Ephemeris.to_json = Mock()
     ublox_ephem.gpsWeek = 0
     ublox_ephem.svId = 1
-    ublox_ephem.toe = 0
+    ublox_ephem.toe = 1
     ephemeris = convert_ublox_gps_ephem(ublox_ephem)
 
     # Should roll-over twice with steps of 1024
-    updated_time = GPSTime(ublox_ephem.gpsWeek + 2048, 0)
+    updated_time = GPSTime(ublox_ephem.gpsWeek + 2048, 1)
     self.assertEqual(ephemeris.epoch, updated_time)
 
     # Check only one roll-over when passing extra argument current_time
-    roll_over_time = GPSTime(1024, 0).as_datetime()
+    roll_over_time = GPSTime(1024, 1).as_datetime()
     ephemeris = convert_ublox_gps_ephem(ublox_ephem, roll_over_time)
 
     # Should roll-over twice with 1024
-    updated_time = GPSTime(ublox_ephem.gpsWeek + 1024, 0)
+    updated_time = GPSTime(ublox_ephem.gpsWeek + 1024, 1)
     self.assertEqual(updated_time, ephemeris.epoch)
 
 


### PR DESCRIPTION
GPS weeks are increased from Saturday night to monday morning (UTC), many saturday night drives get invalid ephemeris times, cause the ephemeris is valid for the next week with toe 0, but we use the current  week. So we end up with current week and toe 0, which results in a date thats 7days off, which can be seen in a comparison to the GLONASS ephems:
```
G07 <GPSEphemeris from G07 at 2023-01-29T00:00:00.000000>
R09 <GLONASSEphemeris from R09 at 2023-02-04T22:15:00.000000>
``` 
after this fix we get:
```
G07 <GPSEphemeris from G07 at 2023-02-05T00:00:00.000000>
R09 <GLONASSEphemeris from R09 at 2023-02-04T22:15:00.000000>
```

not sure if this  is the correct way to fix this, but havent found a better way yet