### PR TITLE
include capnp files in install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     'pycapnp',
   ],
   ext_modules=[],
+  package_data={'': ['*.capnp']},
   description="GNSS library for use with the comma.ai ecosystem",
   long_description='See https://github.com/commaai/laika',
   classifiers=[


### PR DESCRIPTION
setup.py by default will only include .py files. This adds .capnp files as well so the new ephemeris.capnp file is included when someone pip installs.